### PR TITLE
Remove error from the NewMockClient call

### DIFF
--- a/mocks/client.go
+++ b/mocks/client.go
@@ -27,7 +27,7 @@ type MockClient struct {
 }
 
 var (
-	errNoMoreExpectations = errors.New("no more expecations")
+	errNoMoreExpectations = errors.New("no more expectations")
 )
 
 // NewMockClient returns a client that satisfies minitel.Client, but provides additional
@@ -53,7 +53,7 @@ func (c *MockClient) Notify(p minitel.Payload) (result minitel.Result, err error
 		}
 		return minitel.Result{}, next
 	}
-	c.t.Errorf("no more notify expecations")
+	c.t.Errorf("no more notify expectations")
 	return minitel.Result{}, errNoMoreExpectations
 }
 
@@ -71,7 +71,7 @@ func (c *MockClient) Followup(id, body string) (result minitel.Result, err error
 		return minitel.Result{}, next
 	}
 
-	c.t.Errorf("no more followup expecations")
+	c.t.Errorf("no more followup expectations")
 	return minitel.Result{}, errNoMoreExpectations
 }
 

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -32,12 +32,12 @@ var (
 
 // NewMockClient returns a client that satisfies minitel.Client, but provides additional
 // methods to be used for setting expectations around calls to Notify and Followup.
-func NewMockClient(t ErrorReporter) (*MockClient, error) {
+func NewMockClient(t ErrorReporter) *MockClient {
 	return &MockClient{
 		t:                    t,
 		notifyExpectations:   make([]error, 0),
 		followupExpectations: make([]error, 0),
-	}, nil
+	}
 }
 
 // Notify will succeed if there is a notify expectation waiting, otherwise it will fail

--- a/mocks/client_test.go
+++ b/mocks/client_test.go
@@ -31,7 +31,7 @@ func TestNotifySuccess(t *testing.T) {
 	r := newTestReporterMock()
 
 	errFoo := errors.New("error foo")
-	client, _ := NewMockClient(r)
+	client := NewMockClient(r)
 	client.NotifyAndExpectSuccess()
 	client.NotifyAndExpectFailure(errFoo)
 
@@ -59,7 +59,7 @@ func TestFollowupSuccess(t *testing.T) {
 	r := newTestReporterMock()
 
 	errFoo := errors.New("error foo")
-	client, _ := NewMockClient(r)
+	client := NewMockClient(r)
 	client.FollowupAndExpectSuccess()
 	client.FollowupAndExpectFailure(errFoo)
 
@@ -85,7 +85,7 @@ func TestFollowupSuccess(t *testing.T) {
 
 func TestExpectDone(t *testing.T) {
 	r := newTestReporterMock()
-	client, _ := NewMockClient(r)
+	client := NewMockClient(r)
 	client.NotifyAndExpectSuccess()
 	client.FollowupAndExpectSuccess()
 	client.ExpectDone()


### PR DESCRIPTION
This is built on top of #6 and drops the error part of the NewMockClient return.

This is never anything other than `nil` and the callers are all discarding it.