### PR TITLE
Add predictable results to the mock

### DIFF
--- a/mocks/client.go
+++ b/mocks/client.go
@@ -27,7 +27,7 @@ type MockClient struct {
 }
 
 var (
-	errNoMoreExpectations = errors.New("no more expecations")
+	errNoMoreExpectations = errors.New("no more expectations")
 )
 
 // NewMockClient returns a client that satisfies minitel.Client, but provides additional
@@ -53,7 +53,7 @@ func (c *MockClient) Notify(p minitel.Payload) (result minitel.Result, err error
 		}
 		return minitel.Result{}, next
 	}
-	c.t.Errorf("no more notify expecations")
+	c.t.Errorf("no more notify expectations")
 	return minitel.Result{}, errNoMoreExpectations
 }
 
@@ -71,7 +71,7 @@ func (c *MockClient) Followup(id, body string) (result minitel.Result, err error
 		return minitel.Result{}, next
 	}
 
-	c.t.Errorf("no more followup expecations")
+	c.t.Errorf("no more followup expectations")
 	return minitel.Result{}, errNoMoreExpectations
 }
 

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -32,12 +32,12 @@ var (
 
 // NewMockClient returns a client that satisfies minitel.Client, but provides additional
 // methods to be used for setting expectations around calls to Notify and Followup.
-func NewMockClient(t ErrorReporter) (*MockClient, error) {
+func NewMockClient(t ErrorReporter) *MockClient {
 	return &MockClient{
 		t:                    t,
 		notifyExpectations:   make([]error, 0),
 		followupExpectations: make([]error, 0),
-	}, nil
+	}
 }
 
 // Notify will succeed if there is a notify expectation waiting, otherwise it will fail

--- a/mocks/client_test.go
+++ b/mocks/client_test.go
@@ -32,14 +32,14 @@ func TestNotifySuccess(t *testing.T) {
 
 	errFoo := errors.New("error foo")
 	client := NewMockClient(r)
-	client.NotifyAndExpectSuccess()
+	expectedUUID := client.NotifyAndExpectSuccess()
 	client.NotifyAndExpectFailure(errFoo)
 
 	res, err := client.Notify(minitel.Payload{})
 	if err != nil {
 		t.Errorf("Expected success, got failure = %q", err)
-	} else if res.Id == "" {
-		t.Errorf("Expected result with non empty Id")
+	} else if res.Id != expectedUUID {
+		t.Errorf("Expected %s, got %s", expectedUUID, res.Id)
 	}
 
 	res, err = client.Notify(minitel.Payload{})
@@ -60,14 +60,14 @@ func TestFollowupSuccess(t *testing.T) {
 
 	errFoo := errors.New("error foo")
 	client := NewMockClient(r)
-	client.FollowupAndExpectSuccess()
+	expectedUUID := client.FollowupAndExpectSuccess()
 	client.FollowupAndExpectFailure(errFoo)
 
 	res, err := client.Followup("id", "body")
 	if err != nil {
 		t.Errorf("Expected success, got failure = %q", err)
-	} else if res.Id == "" {
-		t.Errorf("Expected result with non empty Id")
+	} else if res.Id != expectedUUID {
+		t.Errorf("Expected %s, got %s", expectedUUID, res.Id)
 	}
 
 	res, err = client.Followup("id", "body")

--- a/mocks/client_test.go
+++ b/mocks/client_test.go
@@ -31,7 +31,7 @@ func TestNotifySuccess(t *testing.T) {
 	r := newTestReporterMock()
 
 	errFoo := errors.New("error foo")
-	client, _ := NewMockClient(r)
+	client := NewMockClient(r)
 	client.NotifyAndExpectSuccess()
 	client.NotifyAndExpectFailure(errFoo)
 
@@ -59,7 +59,7 @@ func TestFollowupSuccess(t *testing.T) {
 	r := newTestReporterMock()
 
 	errFoo := errors.New("error foo")
-	client, _ := NewMockClient(r)
+	client := NewMockClient(r)
 	client.FollowupAndExpectSuccess()
 	client.FollowupAndExpectFailure(errFoo)
 
@@ -85,7 +85,7 @@ func TestFollowupSuccess(t *testing.T) {
 
 func TestExpectDone(t *testing.T) {
 	r := newTestReporterMock()
-	client, _ := NewMockClient(r)
+	client := NewMockClient(r)
 	client.NotifyAndExpectSuccess()
 	client.FollowupAndExpectSuccess()
 	client.ExpectDone()


### PR DESCRIPTION
This changes the `NotifyAndExpectSuccess` and ` FollowupAndExpectSuccess` calls to return a UUID string that will be the `Result.Id` of the successful response.

This is built ontop of #7 