### PR TITLE
TYPES: Add dashboard type

### DIFF
--- a/minitel.go
+++ b/minitel.go
@@ -65,7 +65,7 @@ func (n Notification) Validate() error {
 		return errNoTypeSpecified
 	}
 	switch n.Target.Type {
-	case App, User, Email:
+	case App, User, Email, Dashboard:
 	default:
 		return fmt.Errorf("minitel: Specified Target.Type is unknown: %s", n.Target.Type)
 	}

--- a/minitel.go
+++ b/minitel.go
@@ -17,9 +17,10 @@ type Type string
 
 // Known Telex notification target ypes.
 const (
-	App   Type = "app"
-	User  Type = "user"
-	Email Type = "email"
+	App       Type = "app"
+	User      Type = "user"
+	Email     Type = "email"
+	Dashboard Type = "dashboard"
 )
 
 // Notification message accepted by Telex.

--- a/miniteltest/expectations.go
+++ b/miniteltest/expectations.go
@@ -18,7 +18,7 @@ import (
 // TestServer implements the basic interactions with Minitel for the
 // purposes of testing. Use ExpectNotify and ExpectFollowup to register
 // http.Responses with the handler for controlled testing of responses. Or call
-// those methods with nil to get a generic response. The Wait() method can be
+// those methods with nil to get a generic response. The ExpectDone() method can be
 // used to ensure that all expectations have happened within the provided
 // timeout, which is useful for when the client is used async.
 type TestServer struct {


### PR DESCRIPTION
## Context

A while ago, when opex was thinking about all the types of
notifications, we thought having `TYPE=dashboard` would be useful.

The goal of `TYPE=dashboard` is to create a notification, without sending
an email, and that would purely be visible in the notifications tab.

## Why now?

SDDTLS (spaces-default-domain-tls) was recently launched. When you
create a private space app, we automatically provision a letsencrypt
TLS certificate. It would be great if we can create a notification as soon
as the cert is created, and uploaded to the app successfully -- without
sending an email.

## Metadata

Connects to https://github.com/heroku/runtime/issues/2730